### PR TITLE
Change current Plan

### DIFF
--- a/funkapi/api.py
+++ b/funkapi/api.py
@@ -1,5 +1,6 @@
 import boto3
 import requests
+import datetime
 from warrant.aws_srp import AWSSRP
 
 from funkapi.graphql_schema import schema
@@ -160,7 +161,15 @@ class FunkAPI:
         :return: Current plan
         """
 
-        return self.getData(refresh=refresh_data)["data"]["me"]["customerProducts"][0]["tariffs"][-1]
+        now = datetime.datetime.now(datetime.timezone.utc)
+        currentPlan = None
+        for plan in self.getData(refresh=refresh_data)["data"]["me"]["customerProducts"][0]["tariffs"]:
+            planStart = datetime.datetime.strptime(plan["starts"], "%Y-%m-%dT%H:%M:%S.%f%z")
+            if planStart > now:
+                continue
+            currentPlan = plan
+            
+        return currentPlan
 
     def orderPlan(self, plan_id, product_id=None, refresh_data=True):
         """

--- a/funkapi/api.py
+++ b/funkapi/api.py
@@ -168,7 +168,7 @@ class FunkAPI:
             if planStart > now:
                 continue
             currentPlan = plan
-            
+
         return currentPlan
 
     def orderPlan(self, plan_id, product_id=None, refresh_data=True):


### PR DESCRIPTION
If I start a break in my current Plan and immediately cancle the break I have two Plans.
One is the unlimit_firstDay the other is my "regular" 1GB Plan. The current version of this client returns the 1GB Plan, but that start day of this plan is the next day. The App shows me i have selected a "unlimit" plan for the current day.

I think atm the FUNK App/Systems ignores the terminated status and still use the "first" plan in the list. I'm not a python developer but I add a loop to check the start date of each plan. 