### PR TITLE
Updated README with instructions to install from pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To make the most out of this flexibility, I reverse engineered the **API**   to 
 
 ## Installation
 ### Install from pypi
-```
+```sh
 pip3 install funkapi
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ To make the most out of this flexibility, I reverse engineered the **API**   to 
 - pip3 (or just pip on windows)
 
 ## Installation
+### Install from pypi
+```
+pip3 install funkapi
+```
 
+### Install from source
 ```sh
 git clone https://github.com/lagmoellertim/freenet-funk-api.git
 


### PR DESCRIPTION
Added instructions about how to install from pypi. As this was noticed in a #6 but never added into README. 